### PR TITLE
En el nuevo pre-loader

### DIFF
--- a/app.js
+++ b/app.js
@@ -71,7 +71,7 @@ $.ajax({
 		//alert(Descrip_ind);
 
 		//inicio =  1;
-		setTimeout(function(){$('#preloader').fadeOut('slow',function(){$(this).remove();});},3000);
+		$('#loader').delay(2000).fadeOut("slow");
   },
   async:false
 });

--- a/explora.html
+++ b/explora.html
@@ -124,18 +124,16 @@ svg g.c3-chart-line g.c3-circles-Estados-Unidos-Mexicanos circle{
       z-index: 10000;
     }
 
-  #loader p {
+   #loader p {
       display: block;
-      /*width: 300px;
-      height: 30px;*/
-      font-size: 30px;
+      font-size: 40px;
       position: absolute;
-      top: -100px;
-      /*left: 0;*/
+      top: -70px;
+      /* left: 0; */
       bottom: 0;
       right: 15px;
-      color: #fff !important
-      /*margin: auto;*/
+      color: #fff !important /*margin: auto;*/;
+      text-align: right;
     }
 
      #loader p #tex{
@@ -156,9 +154,7 @@ svg g.c3-chart-line g.c3-circles-Estados-Unidos-Mexicanos circle{
 
     <script type="text/javascript" src="lib/jquery.section-scroll.js"></script>
        <span id="loader" style="display:none">
-    <p><img src="img/logorueda.gif" alt="Cargando..." style="padding-left: 45%"></p>
-    <br>
-    <p style="color:#333; padding-top: 100px; ">Cargando información</p>
+    <p style="color:#333; padding-top: 100px; ">Cargando<br>información</p>
   </span>
     <script>
        $('#loader').show();

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 
   <script src='funcionesApi.js'></script>
   <span id="loader">
-    <p style="color:#333; padding-top: 100px; ">Cargando información</p>
+    <p style="color:#333; padding-top: 100px; ">Cargando<br>información</p>
   </span>
   <script type="text/javascript">
     //$(window).load(function(){
@@ -58,16 +58,14 @@
 
     #loader p {
       display: block;
-      /*width: 300px;
-      height: 30px;*/
-      font-size: 30px;
+      font-size: 40px;
       position: absolute;
-      top: -100px;
-      /*left: 0;*/
+      top: -70px;
+      /* left: 0; */
       bottom: 0;
       right: 15px;
-      color: #fff !important
-      /*margin: auto;*/
+      color: #fff !important /*margin: auto;*/;
+      text-align: right;
     }
 
      #loader p #tex{

--- a/indicadores.html
+++ b/indicadores.html
@@ -134,8 +134,7 @@
       max-width: 32%;
     }
 
-    #preloader { position: fixed; left: 0; top: 0; z-index: 99999999999999999; width: 100%; height: 100%; overflow: visible; 
-              background: rgba(62, 60, 60, 0.6) url('http://files.mimoymima.com/images/loading.gif') no-repeat center center; }
+   
 
 
 
@@ -167,6 +166,35 @@
     table.dataTable thead .sorting_asc {
       background-image: url(DataTables-1.10.13/images/sort_asc.png);
       background-color: #fff;
+    }
+
+
+             #loader {
+      display: block;
+      background: rgba(62, 60, 60, 0.6);
+      color: white;
+      width: 100%;
+      height: 100%;
+      position: fixed;
+      top: 0;
+      left: 0;
+      z-index: 10000;
+    }
+
+  #loader p {
+      display: block;
+      font-size: 40px;
+      position: absolute;
+      top: -70px;
+      /* left: 0; */
+      bottom: 0;
+      right: 15px;
+      color: #fff !important /*margin: auto;*/;
+      text-align: right;
+    }
+
+     #loader p #tex{
+      width: 300px;
     }
 
     </style>
@@ -227,7 +255,9 @@
     <script type="text/javascript" charset="utf8" src="DataTables/DataTables-1.10.13/js/jquery.dataTables.js"></script>
     <script type="text/javascript" charset="utf8" src="DataTables/dataTables.fixedColumns.js"></script>
   </head>
-  <div id="preloader"><div style="position: absolute;right: 50%;top:50%;transform:translate(-50%,-50%);z-index: 999999999999999999999999">Cargando...</div></div>
+  <span id="loader">
+    <p style="color:#333; padding-top: 100px; ">Cargando<br>información</p>
+  </span>
   <body>
 
 

--- a/objetivos.html
+++ b/objetivos.html
@@ -41,18 +41,16 @@
       z-index: 10000;
     }
 
- #loader p {
+  #loader p {
       display: block;
-      /*width: 300px;
-      height: 30px;*/
-      font-size: 30px;
+      font-size: 40px;
       position: absolute;
-      top: -100px;
-      /*left: 0;*/
+      top: -70px;
+      /* left: 0; */
       bottom: 0;
       right: 15px;
-      color: #fff !important;
-      /*margin: auto;*/
+      color: #fff !important /*margin: auto;*/;
+      text-align: right;
     }
 
      #loader p #tex{
@@ -64,9 +62,7 @@
 
 
     <span id="loader">
-    <p><img src="img/logorueda.gif" alt="Cargando..." style="padding-left: 45%"></p>
-    <br>
-    <p style="color:#333; padding-top: 100px; ">Cargando información</p>
+    <p style="color:#333; padding-top: 100px; ">Cargando<br>información</p>
   </span>
 <script>
   


### PR DESCRIPTION
En el nuevo pre-loader, bajar las letras para que no se encimen al menú de arriba y hacerlas más grandes. Probemos incluso con poner el texto en dos renglones, alineado del lado derecho