### PR TITLE
bloque 3

### DIFF
--- a/explora.html
+++ b/explora.html
@@ -140,6 +140,14 @@ svg g.c3-chart-line g.c3-circles-Estados-Unidos-Mexicanos circle{
       width: 300px;
     }
 
+    .crop {
+     width: 185px; 
+     line-height: 18px; 
+     height: 54px; 
+     overflow: hidden; 
+     margin: 0 auto; 
+     text-align: left; 
+   }
 
     @media only screen and (max-width: 1555px) {
         
@@ -409,7 +417,7 @@ svg g.c3-chart-line g.c3-circles-Estados-Unidos-Mexicanos circle{
         </div>
       </div>
 
-      <div id="datosNacional">
+  <!--     <div id="datosNacional">
         <div class="row">
           <div class="col s12">
             <h3 class="fuerte t_principal">Promedio regional y global</h3>
@@ -431,7 +439,7 @@ svg g.c3-chart-line g.c3-circles-Estados-Unidos-Mexicanos circle{
             <h4 class="fuerte t_principal"><strong>13.1</strong></h4>
           </div>
         </div>
-      </div>
+      </div> -->
 
       <div class="row scrollable-section" data-section-title="Descarga de datos">
         <div class="col s12">
@@ -628,6 +636,7 @@ svg g.c3-chart-line g.c3-circles-Estados-Unidos-Mexicanos circle{
   <script type="text/javascript" src="http://canvg.github.io/canvg/canvg.js"></script>
   <script type="text/javascript" src="lib/html2canvas.js"></script>
   <script src='funcionesApi.js'></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jQuery.dotdotdot/1.7.4/jquery.dotdotdot.min.js"></script>
   <script type="text/javascript">
         var titulo_des_graf="Razón de mortalidad materna";
         var objeto;
@@ -1110,9 +1119,10 @@ function busqueda_anio(cadena)
 	     $('.info2').removeClass('hide');
 	     if(props != undefined)
 	     {
-		      this._div.innerHTML='<div><h5 style="font-weight:bold">' + props.nom_ent +'</h5><br><div>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b style="font-size: 20px;color: #00aeef;">' + busqueda_estado(props.nom_ent).toFixed(2)/*props.density*/ + '</b><p style="position: absolute; top: 15%; left: 35%;" id="tit_map_des">'+titulo_des_graf+'</p></div></div><div class="info"></div>';
+		      this._div.innerHTML='<div><h5 style="font-weight:bold">' + props.nom_ent +'</h5><br><div>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b style="font-size: 20px;color: #00aeef;">' + busqueda_estado(props.nom_ent).toFixed(2)/*props.density*/ + '</b><p style="position: absolute; top: 15%; left: 35%;" id="tit_map_des" class="crop">'+titulo_des_graf+'</p></div></div><div class="info"></div>';
           console.log("busqueda",estados[busqueda_indice(props.nom_ent)]);
 			  gen(estados[busqueda_indice(props.nom_ent)]);
+        $(".crop").dotdotdot();
 	     }
 /*
         this._div.innerHTML = '<div><h4>Aguas tratadas</h4>' +  (props ?

--- a/indicadores.html
+++ b/indicadores.html
@@ -254,9 +254,9 @@
     </div>
 <!-- menu -->
 <!-- // verde #299e33 -->
-    <div id="sti" style="background-color:#299e33; position:fixed; width:100%; height:110px; z-index: 9999; color: #fff;">
+    <div id="sti" style="background-color:#299e33; position:fixed; width:100%; height:110px; z-index: 9999; color: #fff; ">
       <div class="container" style="margin-top: 0 !important;">
-      <div class="row">
+      <div class="row" style="margin-top: 8px;">
         <div class="col s2 center-align">
             <img src="img/ods-03.png" style="width: 38%;" alt="">
         </div>
@@ -562,7 +562,7 @@
       </div>
       </div>
     <div class="row">
-      <div class="col s4 offset-s3 right-align" >
+      <div class="col s4 offset-s8 right-align" >
         <a class="waves-effect waves-light btn color claro t_sm sin_sombra marg_top modal-trigger" href="#modalMapa" style="width: 250px;">Exportar gráfica</a>
       </div>
     </div>
@@ -577,12 +577,12 @@
                 <div class="col s4">
                   <p class="fuerte t_normal">Nombre</p>
                 </div>
-                <div class="col s2">
+            <!--     <div class="col s2">
                       <p class="fuerte t_normal">Mapa</p>
                 </div>
                 <div class="col s2">
                       <p class="fuerte t_normal">Grafica</p>
-                </div>
+                </div> -->
                 <div class="col s3">
                       <p class="fuerte t_normal">Datos del indicador</p>
                 </div>
@@ -592,14 +592,14 @@
                 <div class="col s4">
                       <p class="gris t_sm">3.1.1 Razón de mortalidad materna</p>
                 </div>
-                <div class="col s2" style="margin-top: 10px;">
+            <!--     <div class="col s2" style="margin-top: 10px;">
                   <a class="icn">SHP</a>
                   <a class="icns">SHP</a>
                 </div>
                 <div class="col s2" style="margin-top: 10px;">
                   <a class="icn">SHP</a>
                   <a class="icns">SHP</a>
-                </div>
+                </div> -->
                 <div class="col s3" style="margin-top: 10px;">
                       <a class="icn">CSV</a>
                       <a class="icns">XLS</a>
@@ -612,14 +612,14 @@
                 <div class="col s4">
                       <p class="gris t_sm">3.1.1 Razón de mortalidad materna</p>
                 </div>
-                <div class="col s2" style="margin-top: 10px;">
+       <!--          <div class="col s2" style="margin-top: 10px;">
                   <a class="icn">SHP</a>
                   <a class="icns">SHP</a>
                 </div>
                 <div class="col s2" style="margin-top: 10px;">
                   <a class="icn">SHP</a>
                   <a class="icns">SHP</a>
-                </div>
+                </div> -->
                 <div class="col s3" style="margin-top: 10px;">
                       <a class="icn">CSV</a>
                       <a class="icns">XLS</a>
@@ -741,7 +741,6 @@
           x : {
               type : 'timeseries',
               tick: {
-                  rotate:90,
                   format: function (x) { return x.getFullYear(); }
                 //format: '%Y' // format string is also available for timeseries data
               },   
@@ -1862,8 +1861,8 @@ var datos_doble = '<div class="cuadro_titulo"> ' + titulo +
       if ($(window).scrollTop() == 0)
       {
         console.log("arriba");
-        $("#sti").fadeOut(200);
-        $("#esconder").fadeIn(2000);
+        $("#sti").fadeOut(30);
+        $("#esconder").fadeIn(200);
         // $( "#sti" ).animate({
         //   height: "0px"
         // }, 1500 );


### PR DESCRIPTION
Para los indicadores con desagregación NACIONAL, inhabilitar temporalmente la sección "Promedio regional y global"

Solucionar el bug con el fade del banner verde.

Una vez que el banner se queda sticky, igualar margen de arriba y abajo. Ver imagen

En la sección de Datos, quitar las opciones para exportar SHP de Mapa y Gráfica. Sólo dejaremos los botones de arriba para compartir estos elementos.

Alinear del lado derecho el botón de "Exportar gráfica", como en "Exportar mapa"