### PR TITLE
mejora a la funcionalidad datos para calculo en filtros

### DIFF
--- a/app.js
+++ b/app.js
@@ -129,6 +129,7 @@ $.ajax({
 
     $('#insumo_change_cob').on('change',function(){
       put_filtros_insumo_cob($(this).val());
+      $('#insumos_cont').html('');
     });
 
     $('#este').on('change', function(){


### PR DESCRIPTION
ALTA: En Datos para el Cálculo, cambiar el nombre de los datos que aparecen en la tabla tomándolo de la API, para que corresponda con el de la serie seleccionada en el menú dropdown. Actualmente se mantiene el nombre del indicador